### PR TITLE
Single quoted check_multi labels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 **pnp-0.6.16 ??/??/2011**
+  * Bugfix:  Fixed single quoted check_multi labels (reported by Matthias Flacke)
 
 **pnp-0.6.15 09/15/2011**
   * Bugfix:  Fixed Overview link (reported by Stefan Triep)

--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -986,7 +986,7 @@ sub parse_perfstring {
     #
     # check_multi
     #
-    if ( $perfstring =~ /^([a-zA-Z0-9\.\-_\s\/\#]+)::([a-zA-Z0-9\.\-_\s]+)::([^=]+)=/ ) {
+    if ( $perfstring =~ /^[']?([a-zA-Z0-9\.\-_\s\/\#]+)::([a-zA-Z0-9\.\-_\s]+)::([^=]+)[']?=/ ) {
         $is_multi = 1;
         print_log( "check_multi Perfdata start", 3 );
         my $count        = 0;
@@ -1001,7 +1001,7 @@ sub parse_perfstring {
                 @perfs = ();
                 last;
             }
-            if ( $p{label} =~ /^([a-zA-Z0-9\.\-_\s\/\#]+)::([a-zA-Z0-9\.\-_\s]+)::([^=]+)$/ ) {
+            if ( $p{label} =~ /^[']?([a-zA-Z0-9\.\-_\s\/\#]+)::([a-zA-Z0-9\.\-_\s]+)::([^=]+)[']?$/ ) {
                 @multi = ( $1, $2, $3 );
                 if ( $count == 0 ) {
                     print_log( "DEBUG: First check_multi block", 3 );


### PR DESCRIPTION
Hi Joerg,

for the background see the following thread in nagios-portal.de:
http://www.nagios-portal.org/wbb/index.php?page=Thread&threadID=23827

The root cause for the problem are single quoted check_multi labels, which are not yet covered by parse_perfdata in pp.pl.

This commit fixes this behaviour. It adds the regex [']? to each start and end. I don't expect side effects, since 0 and 1 occurrences of single quotes are handled.

Cheers,
-Matthias
