### PR TITLE
Remove obsolete “use_load_threshold” documentation

### DIFF
--- a/share/pnp/documents/de_DE/doc_complete.html
+++ b/share/pnp/documents/de_DE/doc_complete.html
@@ -1736,7 +1736,7 @@ Höhe und Breite der RRD-Graphen bei PDFs
 
 <p>
 
-Zusätzliche Optionen, die bei jedem Aufruf von RRDTool mit übergeben werden. Beispielsweise <code>----slope-mode</code>, um die Graphen etwas zu glätten.
+Zusätzliche Optionen, die bei jedem Aufruf von RRDTool mit übergeben werden. Beispielsweise <code>--slope-mode</code>, um die Graphen etwas zu glätten.
 
 </p>
 <pre class="code"> $conf[&#039;graph_opt&#039;] = &quot;&quot;;</pre>
@@ -2914,7 +2914,6 @@ perfdata_file_run_cmd_args = -b
 npcd_max_threads=5
 
 # greedy options
-use_load_threshold = 0
 load_threshold = 10.0
 
 # Process Options
@@ -3037,23 +3036,9 @@ pid_file=/var/run/npcd.pid
 </li>
 <li class="level1"><div class="li"> <strong>Greedy-Optionen</strong></div>
 <ul>
-<li class="level2"><div class="li"> use_load_threshold  &lt;0 oder 1&gt;</div>
-<ul>
-<li class="level3"><div class="li"> definiert, ob NPCD bei Erreichen des load_thresholds die Anzahl der Threads begrenzen soll</div>
-<ul>
-<li class="level4"><div class="li"> 0 = ausschalten (weitere Threads starten)</div>
-</li>
-<li class="level4"><div class="li"> 1 = einschalten</div>
-</li>
-</ul>
-</li>
-<li class="level3"><div class="li"> <strong>Default:</strong> 0</div>
-</li>
-</ul>
-</li>
 <li class="level2"><div class="li"> load_threshold &lt;float value&gt;</div>
 <ul>
-<li class="level3"><div class="li"> wenn <code>use_load_threshold</code> auf 1 gesetzt ist, werden bei Erreichen dieses load limits keine neuen Threads gestartet</div>
+<li class="level3"><div class="li"> bei Werten größer als 0.0, werden beim Erreichen eines solchen load limits keine neuen Threads gestartet</div>
 </li>
 <li class="level3"><div class="li"> <strong>Default:</strong> 10.0</div>
 </li>

--- a/share/pnp/documents/de_DE/npcd.html
+++ b/share/pnp/documents/de_DE/npcd.html
@@ -152,7 +152,6 @@ perfdata_file_run_cmd_args = -b
 npcd_max_threads=5
 
 # greedy options
-use_load_threshold = 0
 load_threshold = 10.0
 
 # Process Options
@@ -275,23 +274,9 @@ pid_file=/var/run/npcd.pid
 </li>
 <li class="level1"><div class="li"> <strong>Greedy-Optionen</strong></div>
 <ul>
-<li class="level2"><div class="li"> use_load_threshold  &lt;0 oder 1&gt;</div>
-<ul>
-<li class="level3"><div class="li"> definiert, ob NPCD bei Erreichen des load_thresholds die Anzahl der Threads begrenzen soll</div>
-<ul>
-<li class="level4"><div class="li"> 0 = ausschalten (weitere Threads starten)</div>
-</li>
-<li class="level4"><div class="li"> 1 = einschalten</div>
-</li>
-</ul>
-</li>
-<li class="level3"><div class="li"> <strong>Default:</strong> 0</div>
-</li>
-</ul>
-</li>
 <li class="level2"><div class="li"> load_threshold &lt;float value&gt;</div>
 <ul>
-<li class="level3"><div class="li"> wenn <code>use_load_threshold</code> auf 1 gesetzt ist, werden bei Erreichen dieses load limits keine neuen Threads gestartet</div>
+<li class="level3"><div class="li"> bei Werten größer als 0.0, werden beim Erreichen eines solchen load limits keine neuen Threads gestartet</div>
 </li>
 <li class="level3"><div class="li"> <strong>Default:</strong> 10.0</div>
 </li>

--- a/share/pnp/documents/en_US/doc_complete.html
+++ b/share/pnp/documents/en_US/doc_complete.html
@@ -2068,7 +2068,7 @@ Screen sizes may vary, pages sizes won&#039;t. The following two directives enab
 
 <p>
 
-Additional options passed with every call of RRDTool, for example <code>----slope-mode</code> to smooth the graphs
+Additional options passed with every call of RRDTool, for example <code>--slope-mode</code> to smooth the graphs
 
 </p>
 <pre class="code"> $conf[&#039;graph_opt&#039;] = &quot;&quot;;</pre>
@@ -3215,7 +3215,6 @@ perfdata_file_run_cmd_args = -b
 npcd_max_threads=5
 
 # greedy options
-use_load_threshold = 0
 load_threshold = 10.0
 
 # Process Options
@@ -3338,23 +3337,9 @@ pid_file=/var/run/npcd.pid
 </li>
 <li class="level1"><div class="li"> <strong>Greedy Options</strong></div>
 <ul>
-<li class="level2"><div class="li"> use_load_threshold  &lt;0 or 1&gt;</div>
-<ul>
-<li class="level3"><div class="li"> defines if NPCD should _not_ start new threads if your system load is too high</div>
-<ul>
-<li class="level4"><div class="li"> 0 = disable</div>
-</li>
-<li class="level4"><div class="li"> 1 = enable</div>
-</li>
-</ul>
-</li>
-<li class="level3"><div class="li"> <strong>Default:</strong> 0</div>
-</li>
-</ul>
-</li>
 <li class="level2"><div class="li"> load_threshold &lt;float value&gt;</div>
 <ul>
-<li class="level3"><div class="li"> if <code>use_load_threshold</code> is set to 1 this load limit must not be exceeded</div>
+<li class="level3"><div class="li"> values greater than 0.0 prevent new threads from being created if that load limit was reached</div>
 </li>
 <li class="level3"><div class="li"> <strong>Default:</strong> 10.0</div>
 </li>

--- a/share/pnp/documents/en_US/npcd.html
+++ b/share/pnp/documents/en_US/npcd.html
@@ -152,7 +152,6 @@ perfdata_file_run_cmd_args = -b
 npcd_max_threads=5
 
 # greedy options
-use_load_threshold = 0
 load_threshold = 10.0
 
 # Process Options
@@ -275,23 +274,9 @@ pid_file=/var/run/npcd.pid
 </li>
 <li class="level1"><div class="li"> <strong>Greedy Options</strong></div>
 <ul>
-<li class="level2"><div class="li"> use_load_threshold  &lt;0 or 1&gt;</div>
-<ul>
-<li class="level3"><div class="li"> defines if NPCD should _not_ start new threads if your system load is too high</div>
-<ul>
-<li class="level4"><div class="li"> 0 = disable</div>
-</li>
-<li class="level4"><div class="li"> 1 = enable</div>
-</li>
-</ul>
-</li>
-<li class="level3"><div class="li"> <strong>Default:</strong> 0</div>
-</li>
-</ul>
-</li>
 <li class="level2"><div class="li"> load_threshold &lt;float value&gt;</div>
 <ul>
-<li class="level3"><div class="li"> if <code>use_load_threshold</code> is set to 1 this load limit must not be exceeded</div>
+<li class="level3"><div class="li"> values greater than 0.0 prevent new threads from being created if that load limit was reached</div>
 </li>
 <li class="level3"><div class="li"> <strong>Default:</strong> 10.0</div>
 </li>


### PR DESCRIPTION
- Removed any references to the obsolete “use_load_threshold” NPCD
  configuration option.
  As it’s obsolete, users shouldn’t need to know about it.
  Those who still have it will get a warning anyway.
