### PR TITLE
disable subpattern matching in httpd.conf.in

### DIFF
--- a/sample-config/httpd.conf.in
+++ b/sample-config/httpd.conf.in
@@ -20,7 +20,7 @@ Alias @BASE_URL@ "@datarootdir@"
 		# Installation directory
 		RewriteBase @BASE_URL@/
 		# Protect application and system files from being viewed
-		RewriteRule "^(application|modules|system)" - [F]
+		RewriteRule "^(?:application|modules|system)" - [F]
 		# Allow any files or directories that exist to be displayed directly
 		RewriteCond %{REQUEST_FILENAME} !-f
 		RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
- This is a small improvement to the pattern matching.
  It disables the subpattern logic of PCRE for the current subpattern (the “(…)”).
  As this is not used (in form of $1 or so) it speeds up things a tiny bit but has no other effect.
