### PR TITLE
only disable “/application|modules|system” paths

### DIFF
--- a/sample-config/httpd.conf.in
+++ b/sample-config/httpd.conf.in
@@ -20,7 +20,7 @@ Alias @BASE_URL@ "@datarootdir@"
 		# Installation directory
 		RewriteBase @BASE_URL@/
 		# Protect application and system files from being viewed
-		RewriteRule "^(application|modules|system)" - [F]
+		RewriteRule "^(application|modules|system)/" - [F]
 		# Allow any files or directories that exist to be displayed directly
 		RewriteCond %{REQUEST_FILENAME} !-f
 		RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
- The previous patthern "^(?:application|modules|system)" had no trailing “/”.
  This basically means that any URI that starts with one of:
  /application
  /modules
  /system
  thus also things like
  /systemFOO
  would be matched (and subsequentally denied).
  
  We do not use such paths right now, but I think there’s no need to forbid them.
