### PR TITLE
remove traling “/” on a directory option

### DIFF
--- a/sample-config/pnp/npcd.cfg-sample.in
+++ b/sample-config/pnp/npcd.cfg-sample.in
@@ -76,7 +76,7 @@ log_level = 0
 # perfdata_spool_dir = </path/to/directory/>
 #
 
-perfdata_spool_dir = @PERFDATA_SPOOL_DIR@/
+perfdata_spool_dir = @PERFDATA_SPOOL_DIR@
 
 
 # Execute following command for each found file


### PR DESCRIPTION
- Removes the traling “/” on the perfdata_spool_dir option in npcd.cfg-sample.in.
  This is not needed (actually it makes resolution some nano-seconds slower ;-) )
  and just clutters the logfiles, because these have then paths with “//”.
