### PR TITLE
do not use “/var/tmp” for temporary PDF files

### DIFF
--- a/sample-config/pnp/config.php.in
+++ b/sample-config/pnp/config.php.in
@@ -85,7 +85,7 @@ $conf['max_age'] = 60*60*6;
 #
 # Directory for temporary files used for PDF creation 
 #
-$conf['temp'] = "/var/tmp";
+$conf['temp'] = "/tmp";
 #
 # Link back to Nagios or Thruk ( www.thruk.org ) 
 #


### PR DESCRIPTION
- As suggested in http://sourceforge.net/mailarchive/message.php?msg_id=29616710
  Switch from using “/var/tmp” to “/tmp” as the directory for temporary files
  during PDF generation.
