### PR TITLE
cosmetic: always use --bulk instead of -b

### DIFF
--- a/sample-config/misccommands.cfg-sample.in
+++ b/sample-config/misccommands.cfg-sample.in
@@ -20,25 +20,25 @@
 #
 # Bulk mode
 #
-#define command{
+#define command {
 #       command_name    process-service-perfdata-file
-#       command_line    @libexecdir@/process_perfdata.pl --bulk=@localstatedir@/service-perfdata
+#       command_line    @libexecdir@/process_perfdata.pl --bulk @localstatedir@/service-perfdata
 #}
 
-#define command{
+#define command {
 #       command_name    process-host-perfdata-file
-#       command_line    @libexecdir@/process_perfdata.pl --bulk=@localstatedir@/host-perfdata
+#       command_line    @libexecdir@/process_perfdata.pl --bulk @localstatedir@/host-perfdata
 #}
 
 #
 # Bulk with NPCD mode
 #
-#define command{
+#define command {
 #       command_name    process-service-perfdata-file
 #       command_line    /bin/mv @localstatedir@/service-perfdata @PERFDATA_SPOOL_DIR@/service-perfdata.$TIMET$
 #}
 
-#define command{
+#define command {
 #       command_name    process-host-perfdata-file
 #       command_line    /bin/mv @localstatedir@/host-perfdata @PERFDATA_SPOOL_DIR@/host-perfdata.$TIMET$
 #}

--- a/sample-config/pnp/npcd.cfg-sample.in
+++ b/sample-config/pnp/npcd.cfg-sample.in
@@ -102,7 +102,7 @@ perfdata_file_run_cmd = @libexecdir@/@pp_pl_name@
 # '<perfdata_file_run_cmd> <perfdata_file_run_cmd_args> <filename_from_spool_dir>'
 #
 
-perfdata_file_run_cmd_args = -b
+perfdata_file_run_cmd_args = --bulk
 
 
 # identify_npcd (optional)


### PR DESCRIPTION
Obviously these two are purely cosmetic, so pick if you like or not :)
- Use the same white space schema (“…command {…”) in all commands of misccommands.cfg-sample.in.
- Use everywhere “--bulk <filename>” instead of “-b”.
