### PR TITLE
custom templates documentation improvements

### DIFF
--- a/share/pnp/documents/de_DE/tpl_custom.html
+++ b/share/pnp/documents/de_DE/tpl_custom.html
@@ -5,12 +5,16 @@
 <div class="level1">
 
 <p>
-
 Wie bereits unter ”<a href="/de/pnp-0.6/tpl" class="wikilink1" title="de:pnp-0.6:tpl">Was sind Templates ?</a>” beschrieben, ist die Darstellung der Graphen abhängig vom verwendeten Check-Command.
 </p>
 
 <p>
-Es gibt jedoch Situationen, in denen dieses Verhalten übersteuert werden muss.
+Es gibt jedoch Situationen, in denen dieses Verhalten übersteuert werden muss, zum Beispiel dann wenn allgemeingültige Commands definiert wurden.
+</p>
+
+<p>
+PNP, speziell process_perfdata.pl, sucht zur Laufzeit für jedes check_command im Verzeichnis etc/check_commands nach einer Config-Datei ( &lt;check_command&gt;.cfg ) und liest diese, wenn vorhanden, ein.<br/>
+Folgende Optionen können darin definiert werden:
 </p>
 
 </div>
@@ -19,13 +23,7 @@ Es gibt jedoch Situationen, in denen dieses Verhalten übersteuert werden muss.
 <div class="level2">
 
 <p>
-
-Notwendig wird dies, wenn allgemeingültige Commands definiert wurden.
-</p>
-
-<p>
 Beispiel:
-
 </p>
 <pre class="code">
 define command {
@@ -39,10 +37,6 @@ Die Folge wäre, dass immer das Template check_nrpe.php verwendet werden würde,
 </p>
 
 <p>
-PNP, speziell process_perfdata.pl, sucht zur Laufzeit für jedes check_command im Verzeichnis etc/check_commands nach einer Config-Datei ( &lt;check_command&gt;.cfg ) und liest diese, wenn vorhanden, ein.
-</p>
-
-<p>
 Da unser Beispiel-Command check_nrpe lautet, wird nach etc/check_commands/check_nrpe.cfg gesucht.
 </p>
 
@@ -50,9 +44,6 @@ Da unser Beispiel-Command check_nrpe lautet, wird nach etc/check_commands/check_
 Eine Beispiel-Config wird bereits während der Installation mit der Dateierweiterung .cfg-sample in etc/check_commands gespeichert.
 </p>
 
-<p>
-In diesen Config-Files können zwei Optionen gesetzt werden.
-</p>
 <pre class="code">
 # check_command check_nrpe!load!-w 4,4,4 -c 5,5,5
 # ________0__________|       |       |
@@ -74,13 +65,16 @@ CUSTOM_TEMPLATE = 1
 <code>CUSTOM_TEMPLATE = 1,0</code> ergibt → “load_check_nrpe.php”
 </p>
 
+<p>
+Diese Option hat nur Einfluss, wenn die RRD Datenbank neu erstellt wird.
+</p>
+
 </div>
 <!-- SECTION "CUSTOM_TEMPLATE" [250-1697] -->
 <h2><a name="datatype" id="datatype">DATATYPE</a></h2>
 <div class="level2">
 
 <p>
-
 Über die Option “DATATYPE” kann beeinflusst werden, mit welchem Datentyp die RRD-Datenbank angelegt werden soll.
 Default ist in diesem Fall “GAUGE”. Für fortlaufende Werte wird aber hier der Datentyp COUNTER benötigt.
 Normalerweise sollten Plugin-Entwickler für Daten von Typ Counter die Einheit “c” verwenden. Dies ist jedoch nicht immer der Fall.
@@ -88,32 +82,28 @@ Normalerweise sollten Plugin-Entwickler für Daten von Typ Counter die Einheit �
 
 <p>
 Alle Datenreihen auf Typ COUNTER einstellen.
-
 </p>
 <pre class="code">DATATYPE = COUNTER</pre>
 
 <p>
 Einzelnen Datenreihen spezielle Datentypen zuweisen
-
 </p>
 <pre class="code">DATATYPE = GAUGE,GAUGE,COUNTER,COUNTER</pre>
+
+<p>
+Weitere Datentypen sind in der RRDTool-Dokumentation unter <a href="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html" class="urlextern" title="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html"  rel="nofollow">rrdcreate</a> erklärt.
+</p>
 
 <p>
 Diese Option hat nur Einfluss, wenn die RRD Datenbank neu erstellt wird.
 </p>
 
-<p>
-
-Weitere Datentypen sind in der RRDTool-Dokumentation unter <a href="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html" class="urlextern" title="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html"  rel="nofollow">rrdcreate</a> erklärt.
-</p>
-
 </div>
 <!-- SECTION "DATATYPE" [1698-2467] -->
-<h2><a name="min_und_max" id="min_und_max">MIN und MAX</a></h2>
+<h2><a name="min_und_max" id="min_und_max">USE_MIN_ON_CREATE und USE_MAX_ON_CREATE</a></h2>
 <div class="level2">
 
 <p>
-
 In einigen wenigen Situationen ist es notwendig, die für RRDTool gültigen Daten zu begrenzen.
 </p>
 
@@ -124,15 +114,17 @@ Weitere Infos unter <a href="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html
 
 <p>
 Berücksichtigen des Maximum-Wertes aus den Performance-Daten
-
 </p>
 <pre class="code">USE_MAX_ON_CREATE = 1</pre>
 
 <p>
 Berücksichtigen des Minimum-Wertes aus den Performance-Daten
-
 </p>
 <pre class="code">USE_MIN_ON_CREATE = 1</pre>
+
+<p>
+Diese Option hat nur Einfluss, wenn die RRD Datenbank neu erstellt wird.
+</p>
 
 </div>
 <!-- SECTION "MIN und MAX" [2468-2939] -->
@@ -141,7 +133,6 @@ Berücksichtigen des Minimum-Wertes aus den Performance-Daten
 <pre class="code">RRD_STORAGE_TYPE = SINGLE</pre>
 
 <p>
-
 Die Option RRD_STORAGE_TYPE definiert die Art der Datenhaltung.
 </p>
 
@@ -159,8 +150,11 @@ MULTIPLE: Ein oder mehrere RRD-Datenbanken pro Service. Für jede Datenreihe wir
 
 <p>
 <strong>ACHTUNG:</strong> Daten werden nicht automatisch migriert!<br/>
-
 Ein Konvertierungs-Script finden Sie <a href="/de/pnp-0.6/rrd_convert" class="wikilink1" title="de:pnp-0.6:rrd_convert">hier</a>.
+</p>
+
+<p>
+Diese Option hat nur Einfluss, wenn die RRD Datenbank neu erstellt wird.
 </p>
 
 </div>
@@ -169,7 +163,6 @@ Ein Konvertierungs-Script finden Sie <a href="/de/pnp-0.6/rrd_convert" class="wi
 <div class="level2">
 
 <p>
-
 <strong>Gültig ab PNP 0.6.1</strong>
 </p>
 <pre class="code">RRD_HEARTBEAT = 305</pre>
@@ -183,8 +176,11 @@ Mehr dazu unter <a href="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html" cl
 </p>
 
 <p>
-<a href="/de/pnp-0.6/start" class="wikilink1" title="de:pnp-0.6:start">zurück zur Übersicht</a> | <a href="/de/pnp-0.6/advanced" class="wikilink1" title="de:pnp-0.6:advanced">PNP in verteilten Umgebungen</a>
+Diese Option hat nur Einfluss, wenn die RRD Datenbank neu erstellt wird.
+</p>
 
+<p>
+<a href="/de/pnp-0.6/start" class="wikilink1" title="de:pnp-0.6:start">zurück zur Übersicht</a> | <a href="/de/pnp-0.6/advanced" class="wikilink1" title="de:pnp-0.6:advanced">PNP in verteilten Umgebungen</a>
 </p>
 
 </div>

--- a/share/pnp/documents/en_US/tpl_custom.html
+++ b/share/pnp/documents/en_US/tpl_custom.html
@@ -5,12 +5,16 @@
 <div class="level1">
 
 <p>
-
 As already described under ”<a href="/pnp-0.6/tpl" class="wikilink1" title="pnp-0.6:tpl">What are templates ?</a>” the appearance of graphs depends on the check command used.
 </p>
 
 <p>
-There are situations where this behaviour must be overruled. This has to be done when universal commands have been defined.
+There are situations where this behaviour must be overruled, for example when universal commands have been defined.
+</p>
+
+<p>
+PNP, especially process_perfdata.pl, will search for a config file (&lt;check_command&gt;.cfg) in the etc/check_commands directory and read its contents (if available).<br/>
+The following options can be defined in it:
 </p>
 
 </div>
@@ -19,9 +23,7 @@ There are situations where this behaviour must be overruled. This has to be done
 <div class="level2">
 
 <p>
-
 Example:
-
 </p>
 <pre class="code">
 define command {
@@ -35,10 +37,6 @@ This would lead to a call of the check_nrpe.php template even when the monitored
 </p>
 
 <p>
-PNP, especially process_perfdata.pl, will search for a config file (&lt;check_command&gt;.cfg) in the etc/check_commands directory and read its contents (if available).
-</p>
-
-<p>
 As our example command is called check_nrpe it will be searched for etc/check_commands/check_nrpe.cfg.
 </p>
 
@@ -46,9 +44,6 @@ As our example command is called check_nrpe it will be searched for etc/check_co
 During installation a sample config file with the extension .cfg-sample is copied to etc/check_commands.
 </p>
 
-<p>
-Two options can be set in this config file:
-</p>
 <pre class="code">
 # check_command check_nrpe!load!-w 4,4,4 -c 5,5,5
 # ________0__________|       |       |
@@ -70,43 +65,43 @@ CUSTOM_TEMPLATE = 1
 <code>CUSTOM_TEMPLATE = 1,0</code> results in → “load_check_nrpe.php”
 </p>
 
+<p>
+This option has effect only during creation of the RRD database.
+</p>
+
 </div>
 <!-- SECTION "CUSTOM_TEMPLATE" [277-1539] -->
 <h2><a name="datatype" id="datatype">DATATYPE</a></h2>
 <div class="level2">
 
 <p>
-
 The option “DATATYPE” controls the datatype which is used during creation of the RRD database. Default is “GAUGE”. For consecutive values the type should be “COUNTER”. Plugin-developers should use the unit “c” for counters but this is not always the case.
 </p>
 
 <p>
 To set all datasources to COUNTER
-
 </p>
 <pre class="code">DATATYPE = COUNTER</pre>
 
 <p>
 Setting datasources to different types
-
 </p>
 <pre class="code">DATATYPE = GAUGE,GAUGE,COUNTER,COUNTER</pre>
-
-<p>
-This option has effect only during creation of the RRD database.
-</p>
 
 <p>
 More datatypes are explained in the RRDTool documentation found at <a href="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html" class="urlextern" title="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html"  rel="nofollow">rrdcreate</a>.
 </p>
 
+<p>
+This option has effect only during creation of the RRD database.
+</p>
+
 </div>
 <!-- SECTION "DATATYPE" [1540-2178] -->
-<h2><a name="min_and_max" id="min_and_max">MIN and MAX</a></h2>
+<h2><a name="min_and_max" id="min_and_max">USE_MIN_ON_CREATE and USE_MAX_ON_CREATE</a></h2>
 <div class="level2">
 
 <p>
-
 In a few situations it might be necessary to limit the values which are valid for RRDTool.
 </p>
 
@@ -116,15 +111,17 @@ RRD databases can be created with fixed minimum and maximum values. You will fin
 
 <p>
 Account for the maximum value taken from the performance data
-
 </p>
 <pre class="code">USE_MAX_ON_CREATE = 1</pre>
 
 <p>
 Account for the minimum value taken from the performance data
-
 </p>
 <pre class="code">USE_MIN_ON_CREATE = 1</pre>
+
+<p>
+This option has effect only during creation of the RRD database.
+</p>
 
 </div>
 <!-- SECTION "MIN and MAX" [2179-2646] -->
@@ -133,7 +130,6 @@ Account for the minimum value taken from the performance data
 <pre class="code">RRD_STORAGE_TYPE = SINGLE</pre>
 
 <p>
-
 The option RRD_STORAGE_TYPE defines the kind of data storage.
 </p>
 
@@ -154,13 +150,16 @@ MULTIPLE: One or more RRD databases per service. Each datasource will be stored 
 You will find a conversion script <a href="/pnp-0.6/rrd_convert" class="wikilink1" title="pnp-0.6:rrd_convert">here</a>.
 </p>
 
+<p>
+This option has effect only during creation of the RRD database.
+</p>
+
 </div>
 <!-- SECTION "RRD_STORAGE_TYPE" [2647-3096] -->
 <h2><a name="rrd_heartbeat" id="rrd_heartbeat">RRD_HEARTBEAT</a></h2>
 <div class="level2">
 
 <p>
-
 <strong>Starting with PNP 0.6.1</strong>
 </p>
 <pre class="code">RRD_HEARTBEAT = 305</pre>
@@ -174,8 +173,11 @@ More information at <a href="http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html
 </p>
 
 <p>
-<a href="/pnp-0.6/start" class="wikilink1" title="pnp-0.6:start">back to contents</a> | <a href="/pnp-0.6/advanced" class="wikilink1" title="pnp-0.6:advanced">PNP in distributed environments</a>
+This option has effect only during creation of the RRD database.
+</p>
 
+<p>
+<a href="/pnp-0.6/start" class="wikilink1" title="pnp-0.6:start">back to contents</a> | <a href="/pnp-0.6/advanced" class="wikilink1" title="pnp-0.6:advanced">PNP in distributed environments</a>
 </p>
 
 </div>


### PR DESCRIPTION
- Moved out the general information (when process_perfdata.pl loads which files) of the CUSTOM_TEMPLATE section to the beginning.
- Removed useless empty lines in <p></p> sections.
- Moved the sentence which says "two options" out to the beginning and changed the "two" to "the following".
- As Jörg confirmed, all current options only have effect on RRD creation. Documented this at each of them (especially RRD_HEARTBEAT)
- Changed the heading from “MIN and MAX” to “USE_MIN_ON_CREATE and USE_MAX_ON_CREATE”.
