### PR TITLE
do not expect/set a trailing “/” in CFG_DIR (cosmetic)

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -33,7 +33,7 @@ use vars qw ( $TEMPLATE %NAGIOS $t0 $t1 $rt $delayed_write $rrdfile @ds_create $
 
 my %conf = (
     TIMEOUT            => 15,
-    CFG_DIR            => "@sysconfdir@/",
+    CFG_DIR            => "@sysconfdir@",
     USE_RRDs           => 1,
     RRDPATH            => "@PERFDATA_DIR@",
     RRDTOOL            => "@RRDTOOL@",
@@ -73,7 +73,7 @@ my @default_rrd_create = ( "RRA:AVERAGE:0.5:1:2880", "RRA:AVERAGE:0.5:5:2880", "
 Getopt::Long::Configure('bundling');
 my ( $opt_d, $opt_V, $opt_h, $opt_i, $opt_n, $opt_b, $opt_gm, $opt_pidfile,$opt_daemon );
 my $opt_t = $conf{TIMEOUT};                            # Default Timeout
-my $opt_c = $conf{CFG_DIR} . "process_perfdata.cfg";
+my $opt_c = $conf{CFG_DIR} . "/process_perfdata.cfg";
 GetOptions(
     "V"          => \$opt_V,
     "version"    => \$opt_V,


### PR DESCRIPTION
- Usually it’s dangerous to expect users to end directories at configuration options with “/”.
  Therfore added the “/”-separator there where it’s actually needed (when the directory is concatenated with a file).
- Removed the auto-appended traling “/” at the initialisation of CFG_DIR with the configure macros.
  At later places, the separating “/” was already used cleanly, and there this would have lead to double “//”, which is kind of ugly in log output and that like.
