### PR TITLE
drop RRA_STEP from process-perfdata.cfg

### DIFF
--- a/sample-config/pnp/process_perfdata.cfg-sample.in
+++ b/sample-config/pnp/process_perfdata.cfg-sample.in
@@ -50,11 +50,6 @@ RRD_HEARTBEAT = 8460
 RRA_CFG = @sysconfdir@/rra.cfg
 
 #
-# Interval at which PDPs are generated
-#
-RRA_STEP = 60
-
-#
 # Name of the log file
 #
 LOG_FILE = @PERFDATA_LOG@


### PR DESCRIPTION
- RRA_STEP is set in both, process_perfdata.cfg-sample.in and rra.cfg-sample. There is further a hard-coded default in process_perfdata.pl.in.
- The value from rra.cfg-sample seems to override that of process_perfdata.cfg-sample.in.
- Given that IMHO, the RRD/RRA settings should go to rra.cfg and given that there’s a hard-coded default anyway, I dropped RRA_STEP from the config.
  This does not drop the code for reading that value from process-perfdata.cfg from process_perfdata.pl.in, although we should do that probably too.
