### PR TITLE
align RRD start times

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -501,12 +501,12 @@ sub write_rrd {
     if ( !-e "$rrdfile" ) {
         @rrd_create = parse_rra_config($TEMPLATE);
         if ( $conf{USE_RRDs} == 1 ) {
-            print_log( "RRDs::create $rrdfile @rrd_create @ds_create --start=$NAGIOS{TIMET} --step=$conf{RRA_STEP}", 2 );
-            RRDs::create( "$rrdfile", @rrd_create, @ds_create, "--start=$NAGIOS{TIMET}", "--step=$conf{RRA_STEP}" );
+            print_log( "RRDs::create $rrdfile @rrd_create @ds_create --start=0 --step=$conf{RRA_STEP}", 2 );
+            RRDs::create( "$rrdfile", @rrd_create, @ds_create, "--start=0", "--step=$conf{RRA_STEP}" );
 
             my $err = RRDs::error();
             if ($err) {
-            	print_log( "RRDs::create $rrdfile @rrd_create @ds_create --start=$NAGIOS{TIMET} --step=$conf{RRA_STEP}", 0 );
+            	print_log( "RRDs::create $rrdfile @rrd_create @ds_create --start=0 --step=$conf{RRA_STEP}", 0 );
                 print_log( "RRDs::create ERROR $err", 0 );
                 @rrd_state = ( 1, $err );
                 $stats{error}++;
@@ -519,10 +519,10 @@ sub write_rrd {
         }
         else {
             print_log( "RRDs Perl Modules are not installed. Falling back to rrdtool system call.",                           2 );
-            print_log( "$conf{RRDTOOL} create $rrdfile @rrd_create @ds_create --start=$NAGIOS{TIMET} --step=$conf{RRA_STEP}", 2 );
-            system("$conf{RRDTOOL} create $rrdfile @rrd_create @ds_create --start=$NAGIOS{TIMET} --step=$conf{RRA_STEP}");
+            print_log( "$conf{RRDTOOL} create $rrdfile @rrd_create @ds_create --start=0 --step=$conf{RRA_STEP}", 2 );
+            system("$conf{RRDTOOL} create $rrdfile @rrd_create @ds_create --start=0 --step=$conf{RRA_STEP}");
             if ( $? > 0 ) {
-            	print_log( "$conf{RRDTOOL} create $rrdfile @rrd_create @ds_create --start=$NAGIOS{TIMET} --step=$conf{RRA_STEP}", 0 );
+            	print_log( "$conf{RRDTOOL} create $rrdfile @rrd_create @ds_create --start=0 --step=$conf{RRA_STEP}", 0 );
                 print_log( "rrdtool create returns $?", 0 );
                 @rrd_state = ( $?, "create failed" );
                 $stats{error}++;


### PR DESCRIPTION
- This changes the start time of newly created RRDs to "0" (1970-01-01 00:00:00 UTC).

The idea behind is that all RRDs should be "aligned.
Given how RRD works, especially how it interpolates data onto steps, the start time has an influence over which time periods the steps (and PDPs) actually span.

Till now, PNP creates the RRDs with a start time that was set to the time of the first sample of perfdata retrieved from Nagios/Icinga.
These occur at arbitrary times and cannot be aligned, but now even the steps of the RRDs are likely unaligned.

This makes it a bit more vague to comare the values from different sensors.

Giving all RRDs a common start time should solve this problem at, as far as I can see, no disadvantages (not even with respect to RRD performance).
