### PR TITLE
RRD unknown values

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -876,7 +876,7 @@ sub _parse {
     # Nagios::Plugin::Performance
     my $string     = shift;
     my $tmp_string = $string;
-    $string =~ s/^([^=]+)=([\d\.\-]+)([\w\/%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?;?\s*//;
+    $string =~ s/^([^=]+)=(U|[\d\.\-]+)([\w\/%]*);?([\d\.\-:~@]+)?;?([\d\.\-:~@]+)?;?([\d\.\-]+)?;?([\d\.\-]+)?;?\s*//;
 
     if ( $tmp_string eq $string ) {
         print_log( "No pattern match in function _parse($string)", 2 );


### PR DESCRIPTION
Hi Jörg, 

korrigiere mich, wenn ich falsch liege; der Regex passt eigentlich schon. 
Gruppe 2 (value) wird aus dem geänderten
(U|[\d.-]+) 
gebildet. Die Gruppe 3 (unit) ist von der Änderung gar nicht betroffen. Eine Unit kann also auch zusammen mit "U" angegeben werden. 

Danke + Grüße,

Simon

P.S.: mein erster github pull request :-)
