### PR TITLE
Fix timeout in process_perfdata.pl to use what is in the config

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -72,7 +72,7 @@ my @default_rrd_create = ( "RRA:AVERAGE:0.5:1:2880", "RRA:AVERAGE:0.5:5:2880", "
 
 Getopt::Long::Configure('bundling');
 my ( $opt_d, $opt_V, $opt_h, $opt_i, $opt_n, $opt_b, $opt_gm, $opt_pidfile,$opt_daemon );
-my $opt_t = $conf{TIMEOUT};                            # Default Timeout
+my $opt_t = my $opt_t_default = $conf{TIMEOUT}; # Default Timeout
 my $opt_c = $conf{CFG_DIR} . "process_perfdata.cfg";
 GetOptions(
     "V"          => \$opt_V,
@@ -131,6 +131,13 @@ if ( defined($opt_gm) ) {
 
 print_help()    if ($opt_h);
 print_version() if ($opt_V);
+
+# Use the timeout specified on the command line and if none use what is in the configuration
+# If timeout is not in command line or the config file use the default
+$opt_t = $conf{TIMEOUT} if ( $opt_t == $opt_t_default && $opt_t != $conf{TIMEOUT} );
+print_log( "Default Timeout: $opt_t_default secs.", 2 );
+print_log( "Config Timeout: $conf{TIMEOUT} secs.", 2 );
+print_log( "Actual Timeout: $opt_t secs.", 2 );
 
 init_signals();
 my %children = ();       # keys are current child process IDs
@@ -1517,7 +1524,7 @@ sub print_help {
     -V, --version
     Print version information
     -t, --timeout=INTEGER
-    Seconds before process_perfdata.pl times out (default: $opt_t)
+    Seconds before process_perfdata.pl times out (default: $opt_t_default)
     -i, --inetd
     Use this Option if process_perfdata.pl is executed by inetd/xinetd.
     -d, --datatype


### PR DESCRIPTION
It seems as though the timeout option that you can specify in process_perfdata.cfg never
actually gets used. The only timeout that can get used is what is specified as default in the
process_perfdata.pl script or what is put on the command line using -t.

This seems like a bug to me or maybe I am missing something. I'm seeing this
in the latest 0.6.19 release and am using the NPCD bulk mode setup.

This commit is an attempt to try and correct the issue by first taking the timeout
specified on the command line. If there is none specified on the command then use
what is in the configuration file. If a timeout was not specified in either of those
places then use what is configured as the default in the script.
