### PR TITLE
logging: Fixed a missing printf-style format argument

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -27,7 +27,7 @@ extern int max_logfile_size;
 
 int do_log(char *message) {
 	if (use_syslog) {
-		syslog(LOG_NOTICE, message);
+		syslog(LOG_NOTICE, "%s", message);
 		return OK;
 	} else if (use_syslog == FALSE) {
 		if (write_log(message)==0)


### PR DESCRIPTION
This was identified by GCC's format-security check which forbids any non
string literals to be used as format argument.
