### PR TITLE
Added subsys lock file to worker init script

### DIFF
--- a/scripts/rc.pnp_gearman_worker.in
+++ b/scripts/rc.pnp_gearman_worker.in
@@ -48,7 +48,7 @@ function kill_procs() {
         if [ $? -ne 0 ]; then
             rm -f $PIDFILE
             if [ "$USERID" -eq 0 ]; then
-                rm -f $LOCKFILE $PIDFILE
+                rm -f $LOCKFILE
             fi
             echo "done"
             exit 0;


### PR DESCRIPTION
This is required on RHEL style machines to properly handle run level changes.

You can read about it in more detail here which isn't the best documentation I know but the best I could find that validates why this change is necessary.

http://www.redhat.com/magazine/008jun05/departments/tips_tricks/

Just did a similar fix on mod_gearman's init scripts.

https://github.com/sni/mod_gearman/pull/47
