### PR TITLE
Fix for a bug with imgAreaSelect: Use graph_height & graph_width from UR...

### DIFF
--- a/share/pnp/application/models/config.php
+++ b/share/pnp/application/models/config.php
@@ -74,6 +74,11 @@ class Config_Model extends System_Model
             }
         }
 
+        // Use graph_height & graph_width from URL if present
+        if(isset($_GET['h']) && $_GET['h'] != "" ) $conf['graph_height'] = $_GET['h'];
+        if(isset($_GET['w']) && $_GET['w'] != "" ) $conf['graph_width']  = $_GET['w'];
+        if(isset($_GET['graph_height']) && $_GET['graph_height'] != "" ) $conf['graph_height'] = $_GET['graph_height'];
+        if(isset($_GET['graph_width'])  && $_GET['graph_width']  != "" ) $conf['graph_width']  = $_GET['graph_width'];
         $this->conf = $conf;
         $this->views = $views;
         $this->scheme = $scheme;


### PR DESCRIPTION
...L if present

The imgAreaSelect function in application/views/template.php always uses the conf['graph_height'] parameter:
jQuery('div.graph').imgAreaSelect({ handles: false, autoHide: true, fadeSpeed: 500, onSelectEnd: redirect, minHeight: '<?php echo $this->config->conf['graph_height'] ?>' });

If you modify graph_height or graph_width in the URL with h,w,graph_height or graph_width the imgAreaSelect calculation is wrong. This fix will store the parameters from URL in $conf array
