### PR TITLE
Fix graph when range includes negative infinity.

### DIFF
--- a/share/pnp/application/helpers/rrd.php
+++ b/share/pnp/application/helpers/rrd.php
@@ -294,6 +294,9 @@ class rrd_Core {
         if($color === FALSE){
             throw new Kohana_exception("rrd::". __FUNCTION__ . "() Second Parameter 'color' is missing");   
         }
+	if($value == "~" ) {
+	    return "";
+	}
         $line = sprintf("HRULE:%s%s:\"%s\" ",$value,$color,$text);
         return $line;
     }


### PR DESCRIPTION
When a threshold or range contains negative infinity (~)
the graph failes. The routine drawing the threshold line
outputs a rrdgraph line in the form 'HRULE:~#FF0000:"...."'.
rrdtool can not the interpret ~ sign.
This fix just skips the HRULE for negative infinity.
