### PR TITLE
Version Nagios Core 4.0.2 Error-No pattern match in function _parse(\n )...

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -316,6 +316,7 @@ sub process_perfdata {
     $NAGIOS{PERFDATA} =~ s/,/./g;
     $NAGIOS{PERFDATA} =~ s/\s+=/=/g;
     $NAGIOS{PERFDATA} =~ s/=\s+/=/g;
+    $NAGIOS{PERFDATA} =~ s/\\n//g;
     $NAGIOS{PERFDATA} .= " ";
     parse_perfstring( $NAGIOS{PERFDATA} );
     return 1;


### PR DESCRIPTION
...Error on logfile /usr/local/pnp4nagios/var/perfdata.log en VERSIO 4.0.2 - 

2014-01-08 11:48:31 [7489] [2] Datatype set to 'SERVICEPERFDATA' 
2014-01-08 11:48:31 [7489] [1] Found Performance Data for localhost / Current_Users (users=3;20;50;0\n) 
2014-01-08 11:48:31 [7489] [2] No pattern match in function _parse(\n )
2014-01-08 11:48:31 [7489] [1] Invalid Perfdata detected 
2014-01-08 11:48:31 [7489] [1] Gearman job end (runtime 0.001056s) ...
2014-01-08 11:48:42 [7489] [1] Gearman Worker Job start
2014-01-08 11:48:42 [7489] [2] Datatype set to 'HOSTPERFDATA' 
2014-01-08 11:48:42 [7489] [1] Found Performance Data for centos64MysqlT / _HOST_ (rta=0.629000ms;3000.000000;5000.000000;0.000000 pl=0%;80;100;0) 
2014-01-08 11:48:42 [7489] [2] data2rrd called
2014-01-08 11:48:42 [7489] [2] RRDs::update /usr/local/pnp4nagios/var/perfdata/centos64MysqlT/_HOST_.rrd 1389178122:0.629000:0
2014-01-08 11:48:42 [7489] [2] /usr/local/pnp4nagios/var/perfdata/centos64MysqlT/_HOST_.rrd updated
2014-01-08 11:48:42 [7489] [1] Gearman job end (runtime 0.002394s) ...

Add to line 319 "$NAGIOS{PERFDATA} =~ s/\n//g;" to avoid the "No pattern match in function _parse(\n ) "
and get correct perfdata.

```
            $NAGIOS{PERFDATA} =~ s/,/./g;
            $NAGIOS{PERFDATA} =~ s/\s+=/=/g;
            $NAGIOS{PERFDATA} =~ s/=\s+/=/g;
```

 Add this line -->  $NAGIOS{PERFDATA} =~ s/\n//g;
                    $NAGIOS{PERFDATA} .= " ";
- solved
