### PR TITLE
views/timerange_select: escape keys and values

### DIFF
--- a/share/pnp/application/views/timerange_select.php
+++ b/share/pnp/application/views/timerange_select.php
@@ -24,7 +24,7 @@ jQuery(function() {
 					continue;
 				if( $key == "end" )
 					continue;
-				echo "<input type=\"hidden\" name=\"".$key."\" value=\"".$val."\">\n";
+				echo "<input type=\"hidden\" name=\"".htmlspecialchars($key)."\" value=\"".htmlspecialchars($val)."\">\n";
 			}?>
             <label for=start"><?php echo Kohana::lang('common.start') ?>: </label><input id="dpstart" type="text" size="18" maxlength="40" name="start" value="<?php echo $start?>">
 			<label for=end"><?php echo Kohana::lang('common.end') ?>: </label><input id="dpend" type="text" size="18" maxlength="40" name="end" value="<?php echo $end?>">


### PR DESCRIPTION
Escape keys and values of GET parameters before adding them
as hidden inputs in the time range form.

Without escaping, an XSS attack can be performed:
http://example.com/pnp/graph?host=a&srv=b&view=0"><script>alert("busted")</script>
(the host a with service b must exist)

Signed-off-by: Mikael Falkvidd mfalkvidd@op5.com
