### PR TITLE
Fixes to exception message

### DIFF
--- a/share/pnp/application/models/data.php
+++ b/share/pnp/application/models/data.php
@@ -661,7 +661,7 @@ class Data_Model extends System_Model
             if(!is_numeric($end)){
                 $timestamp = strtotime($end);
                 if(!$timestamp){
-                    throw new Kohana_User_Exception('Wrong Format', "$end");
+                    throw new Kohana_User_Exception('Wrong Format', "End -> $end");
                 }else{
                     $end = $timestamp;
                 }


### PR DESCRIPTION
Add in additional information to exception message thrown when the ending time range is incorrectly formatted just like the message for the start time range.
