### PR TITLE
Fix timeranges

### DIFF
--- a/share/pnp/application/controllers/system.php
+++ b/share/pnp/application/controllers/system.php
@@ -23,8 +23,8 @@ class System_Controller extends Template_Controller {
         // Check for mod_rewrite
         $this->check_mod_rewrite();
 
-        $this->start             = pnp::clean($this->input->get('start',FALSE));
-        $this->end               = pnp::clean($this->input->get('end',FALSE));
+        $this->start             = $this->input->get('start',FALSE);
+        $this->end               = $this->input->get('end',FALSE);
         $this->theme             = pnp::clean($this->input->get('theme',FALSE));
         $this->view              = pnp::clean($this->input->get('view', ""));
         $this->host              = pnp::clean($this->input->get('host',NULL));


### PR DESCRIPTION
In commit 25de3550 the start and end times used for timeranges was
subjected to pnp::clean(). This was to help clean/validate all input
parameters to prevent XSS attacks. The problem is pnp::clean() replaces
all slashes with underscores which later breaks the conversion when
running strtotime().

It should be safe to remove cleaning the start and end inputs since they
get sent to getTimeRange() which will throw an exception if the input
can't be converted using strtotime() is not is_numeric().

Fixes #82.
