### PR TITLE
Change the default source NULL instead of zero

### DIFF
--- a/share/pnp/application/controllers/system.php
+++ b/share/pnp/application/controllers/system.php
@@ -29,7 +29,7 @@ class System_Controller extends Template_Controller {
         $this->view              = pnp::clean($this->input->get('view', ""));
         $this->host              = pnp::clean($this->input->get('host',NULL));
         $this->service           = pnp::clean($this->input->get('srv',NULL));
-        $this->source            = pnp::clean($this->input->get('source',0));
+        $this->source            = pnp::clean($this->input->get('source',NULL));
         $this->version           = pnp::clean($this->input->get('version',NULL));
         $this->tpl               = pnp::clean($this->input->get('tpl'));
         $this->controller        = Router::$controller;


### PR DESCRIPTION
In commit 25de3550 the 'source' value was configured to get a default of
zero if no input for source was supplied. This changed the behaviour of
the popup controller for example and possibly others.

After this change, instead of showing all of the graphs for a 'Disk'
check for exmaple, only source zero is shown.

Previously, the 'source' value would be NULL if no input was supplied.
With the value as NULL the popup controller will show all sources unless
a source is supplied as a parameter.
