### PR TITLE
Update NPCD init script to LSB compliant

### DIFF
--- a/scripts/rc.npcd.in
+++ b/scripts/rc.npcd.in
@@ -1,9 +1,9 @@
 #!@SHELL@
-# 
+#
 ### BEGIN INIT INFO
 # Provides:          npcd
-# Required-Start:    
-# Required-Stop:     
+# Required-Start:
+# Required-Stop:
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: @PKG_NAME@ NPCD Daemon Version @PKG_VERSION@
@@ -14,7 +14,7 @@
 #
 # File : npcd
 #
-  
+
 servicename=@npcd_name@
 prefix=@prefix@
 exec_prefix=${prefix}
@@ -47,10 +47,10 @@ printstatus_npcd(){
         exit 0
     elif test $? -eq 2; then
         echo "$servicename is not running but subsystem locked"
-        exit 2
+        exit 3
     else
         echo "$servicename is not running"
-        exit 1
+        exit 3
     fi
 }
 
@@ -86,7 +86,7 @@ if [ ! -f $NpcdCfgFile ]; then
     echo "Configuration file $NpcdCfgFile not found.  Exiting."
     exit 1
 fi
-          
+
 # See how we were called.
 case "$1" in
 
@@ -94,7 +94,7 @@ case "$1" in
         status_npcd
         if [ $? -eq 0 ]; then
             echo "$servicename already started..."
-            exit 1
+            exit 0
         fi
         echo -n "Starting $servicename:"
         touch $NpcdRunFile
@@ -109,7 +109,7 @@ case "$1" in
         status_npcd
         if ! [ $? -eq 0 ]; then
             echo "$servicename was not running... could not stop"
-            exit 1
+            exit 0
         fi
         echo -n "Stopping $servicename: "
 
@@ -136,7 +136,7 @@ case "$1" in
         else
              echo 'done.'
         fi
-        rm -f $NpcdLockDir/$NpcdLockFile 
+        rm -f $NpcdLockDir/$NpcdLockFile
     ;;
 
     status)
@@ -158,5 +158,5 @@ case "$1" in
     ;;
 
 esac
-  
+
 # End of this script


### PR DESCRIPTION
Making the NPCD init script LSB compliant allows for NPCD to be easily
used as a Pacemaker primitive. Refer to the following documentation on
how to make an init script LSB compliant:

http://clusterlabs.org/doc/en-US/Pacemaker/1.0/html/Pacemaker_Explained/ap-lsb.html