### PR TITLE
$srv cannot be encoded if not set

### DIFF
--- a/share/pnp/application/views/zoom.php
+++ b/share/pnp/application/views/zoom.php
@@ -57,11 +57,6 @@ jQuery.noConflict();
 <div style="position:relative;">
 <?php 
 echo "<div start=$start end=$end style=\"width:".$graph_width."px; height:".$graph_height."px; position:absolute; top:33px\" class=\"graph\" id=\"".$this->url."\" ></div>";
-
-if (!empty($srv)){
-    $srv = urlencode($srv);
-}
-
 if(!empty($tpl)){
     echo "<img class=\"graph\" src=\"image?source=$source"
 	."&tpl=$tpl"
@@ -73,7 +68,7 @@ if(!empty($tpl)){
 }else{
     echo "<img src=\"image?source=$source"
 	."&host=$host"
-	."&srv=$srv"
+	."&srv=urlencode($srv)"
 	."&view=$view"
 	."&start=$start"
 	."&end=$end"

--- a/share/pnp/application/views/zoom.php
+++ b/share/pnp/application/views/zoom.php
@@ -57,7 +57,11 @@ jQuery.noConflict();
 <div style="position:relative;">
 <?php 
 echo "<div start=$start end=$end style=\"width:".$graph_width."px; height:".$graph_height."px; position:absolute; top:33px\" class=\"graph\" id=\"".$this->url."\" ></div>";
-$srv = urlencode($srv);
+
+if (!empty($srv)){
+    $srv = urlencode($srv);
+}
+
 if(!empty($tpl)){
     echo "<img class=\"graph\" src=\"image?source=$source"
 	."&tpl=$tpl"


### PR DESCRIPTION
The $srv url encoding was at the wrong place and will give an error if a special template is used with the zoom function. Moved the encoding to the section where $srv is existing.