### PR TITLE
Support Icinga 2 implementation of multi format

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -1044,6 +1044,7 @@ sub parse_perfstring {
         my $check_multi_blockcount = 0;
         my $multi_parent     = cleanup( $NAGIOS{SERVICEDESC} );
         my $auth_servicedesc = $NAGIOS{DISP_SERVICEDESC};
+        my $seen_multi_label = "";
         while ($perfstring) {
             ( $perfstring, %p ) = _parse($perfstring);
             if ( !$p{label} ) {
@@ -1052,8 +1053,19 @@ sub parse_perfstring {
                 @perfs = ();
                 last;
             }
+
+            if ( $p{label} =~ /$seen_multi_label/ ) {
+                # multi label format for each perfdata item (e.g Icinga2)
+                # we're in a sub tree of a multi block, adjust label for further processing
+                my $tmp_prefix = $seen_multi_label."::";
+                $p{label} =~ s/$tmp_prefix//;
+            }
+
             if ( $p{label} =~ /^[']?([a-zA-Z0-9\.\-_\s\/\#]+)::([a-zA-Z0-9\.\-_\s]+)::([^=]+)[']?$/ ) {
                 @multi = ( $1, $2, $3 );
+
+                $seen_multi_label = $multi[0]."::".$multi[1];
+
                 if ( $count == 0 ) {
                     print_log( "DEBUG: First check_multi block", 3 );
 


### PR DESCRIPTION
Icinga 2 has implemented the multi format in another way like it was handled by Icinga 1 / Nagios. 
Developer could not change this but provided a patch for pnp4nagios. I can confirm the patch working with Icinga 2 and also the developer of check_interface_table_v3t did so.

More details can be found at https://dev.icinga.org/issues/8183, the bug report leading to the patch.

I only signed off the patch and created the pull request after the developer told me he has no time to do so and because I needed this fix in one environment and perhaps will need it in others and also others will need it, too.
