### PR TITLE
add new url option graph_only to hide legend

### DIFF
--- a/share/pnp/application/controllers/image.php
+++ b/share/pnp/application/controllers/image.php
@@ -40,6 +40,9 @@ class Image_Controller extends System_Controller  {
         if($this->input->get('graph_height') != "" )
             $this->rrdtool->config->conf['graph_height'] = intval($this->input->get('graph_height'));
 
+        if($this->input->get('graph_only') !== null)
+            $this->rrdtool->config->conf['graph_only'] = 1;
+
         $this->data->getTimeRange($this->start,$this->end,$this->view);
 
         if(isset($this->tpl)){

--- a/share/pnp/application/models/rrdtool.php
+++ b/share/pnp/application/models/rrdtool.php
@@ -106,7 +106,7 @@ class Rrdtool_Model extends System_Model
         if ($height > 0){
             $command .= " --height=$height";
         }
-        if ($height < 81 ){
+        if ($height < 81 || (isset($conf['graph_only']) && $conf['graph_only'])){
             $command .= " --only-graph ";
         }
 


### PR DESCRIPTION
This patch adds a new url option graph_only which appends the --only-graph
option to the rrdtool command line.

Signed-off-by: Sven Nierlein <sven@nierlein.de>