### PR TITLE
fix typo in last pull request

### DIFF
--- a/share/pnp/application/controllers/image.php
+++ b/share/pnp/application/controllers/image.php
@@ -31,8 +31,8 @@ class Image_Controller extends System_Controller  {
         if($this->input->get('graph_only') !== null)
             $this->rrdtool->config->conf['graph_only'] = 1;
 
-        if($this->input->get('hide_legend') !== null)
-            $this->rrdtool->config->conf['hide_legend'] = 1;
+        if($this->input->get('no_legend') !== null)
+            $this->rrdtool->config->conf['no_legend'] = 1;
 
         $this->data->getTimeRange($this->start,$this->end,$this->view);
 


### PR DESCRIPTION
the name of the rrdgraph option is no-legend, so use this name
consistently. Also this key is used in the rrdtool model already.