### PR TITLE
address behaviour of rrdtool1.5+ to not export timestamp by default

### DIFF
--- a/share/pnp/application/models/data.php
+++ b/share/pnp/application/models/data.php
@@ -1019,13 +1019,23 @@ class Data_Model extends System_Model
         foreach($xml->meta->legend->entry as $key=>$value){
             $csv .= ";" . $value ;
         }
+
+        /*
+        * from rrdtool 1.5 on, timestamp ( value->t ) is not set anymore
+        * from 1.6 on it can be reactivated by -- showrime option to rrdtool xport
+        * here we take care of the timestamp ourselves regardless which 
+        * rrdtool version is used
+        */
+        $timestamp2 = $xml->meta->start;
+        $step = $xml->meta->step;
         $csv .= "\n";
         foreach($xml->data->row as $key=>$value){
-            $csv .= (string) $value->t ;
+            $csv .= $timestamp2;
             foreach($value->v as $item){
                 $csv .= ";".floatval((string) $item);
             }
             $csv .= "\n";
+            $timestamp2 = $timestamp2 + $step;
         }
         return $csv;    
     }


### PR DESCRIPTION
from rrdtool version 1.5 onwards, the timestamp is not longer exported with 'rrdtool xpoert..'
in csv export, it is added here by calculating the timestamp from start and step information.
(rrdtool 1.6+ has --showtime extra option to solve the problem)