### PR TITLE
fix non well formed numeric value encountered

### DIFF
--- a/share/pnp/application/helpers/pnp.php
+++ b/share/pnp/application/helpers/pnp.php
@@ -121,6 +121,7 @@ class pnp_Core {
         preg_match('/^(-?[0-9\.,]+)\s*(\S?)(\S?)/',$value,$matches);
 
         $mag = 0;
+        $value = $matches[1];
         while ($value >= $base){
             $value /= $base;
             $mag++;


### PR DESCRIPTION
php 7 is more picky about numbers. adjust_unit() accepts values like
1024MB and then does arithmetic operations on that which worked before
php 7 but now leads to the error above.

Signed-off-by: Sven Nierlein <sven@nierlein.de>