### PR TITLE
controllers/page|special: use zgraph dimensions

### DIFF
--- a/share/pnp/application/controllers/page.php
+++ b/share/pnp/application/controllers/page.php
@@ -13,8 +13,8 @@ class Page_Controller extends System_Controller  {
         $this->template                = $this->add_view('template');
         $this->template->page          = $this->add_view('page');
         $this->template->zoom_header   = $this->add_view('zoom_header');
-        $this->template->zoom_header->graph_width  = ($this->config->conf['graph_width'] + 140);
-        $this->template->zoom_header->graph_height = ($this->config->conf['graph_height'] + 230);
+        $this->template->zoom_header->graph_width  = ($this->config->conf['zgraph_width'] + 140);
+        $this->template->zoom_header->graph_height = ($this->config->conf['zgraph_height'] + 230);
         $this->template->page->graph_content  = $this->add_view('graph_content');
         $this->template->page->graph_content->graph_width = ($this->config->conf['graph_width'] + 85);
         $this->template->page->graph_content->timerange_select = $this->add_view('timerange_select');

--- a/share/pnp/application/controllers/special.php
+++ b/share/pnp/application/controllers/special.php
@@ -25,8 +25,8 @@ class Special_Controller extends System_Controller  {
     public function index(){
 	$this->url = "?tpl=".$this->tpl;
         $this->template->zoom_header   = $this->add_view('zoom_header');
-        $this->template->zoom_header->graph_width  = ($this->config->conf['graph_width'] + 140);
-        $this->template->zoom_header->graph_height = ($this->config->conf['graph_height'] + 230);
+        $this->template->zoom_header->graph_width  = ($this->config->conf['zgraph_width'] + 140);
+        $this->template->zoom_header->graph_height = ($this->config->conf['zgraph_height'] + 230);
         $this->template->graph->graph_content = $this->add_view('graph_content_special');
         $this->template->graph->graph_content->graph_width = ($this->config->conf['graph_width'] + 85);
         $this->template->graph->graph_content->timerange_select = $this->add_view('timerange_select');


### PR DESCRIPTION
This fixes an issue with zoom window being too small on special pages.
Please see graph.php for a current correct usage