### PR TITLE
Service descriptions that contain # characters break drag-to-zoom function

### DIFF
--- a/share/pnp/application/views/graph_content.php
+++ b/share/pnp/application/views/graph_content.php
@@ -83,8 +83,16 @@ foreach($this->data->STRUCT as $key=>$value){
 		.Kohana::lang('common.service',$value['MACRO']['DISP_SERVICEDESC']) . " " 
 		.Kohana::lang('common.datasource',$value['ds_name']) . " " 
 		."\">\n";
-	echo "<div start=".$value['TIMERANGE']['start']." end=".$value['TIMERANGE']['end']." style=\"width:".$value['GRAPH_WIDTH']."px; height:".$value['GRAPH_HEIGHT']."px; position:absolute; top:33px\" class=\"graph\" id=\"".$this->url."\" ></div>";
-        $path = pnp::addToUri( array(
+	
+	# urlencode the graph id, to prevent # chars in service names being 
+	# treated like a url fragment when zooming
+	$gid = array();
+	parse_str(ltrim($this->url, '?'), $gid);
+	$gid = htmlentities("?host=".urlencode($gid["host"])."&srv=".urlencode($gid["srv"]));
+	
+	echo "<div start=".$value['TIMERANGE']['start']." end=".$value['TIMERANGE']['end']." style=\"width:".$value['GRAPH_WIDTH']."px; height:".$value['GRAPH_HEIGHT']."px; position:absolute; top:33px\" class=\"graph\" id=\"".$gid."\" ></div>";
+        
+	$path = pnp::addToUri( array(
                                 'host'   => $value['MACRO']['HOSTNAME'],
                                 'srv'    => $value['MACRO']['SERVICEDESC'],
                                 'view'   => $value['VIEW'],


### PR DESCRIPTION
Patched the `graph_content.php` file to URL-encode the host and service names, when used in URLs for zooming.  This stops `#` and `&` being parsed by the browser and breaking the zoom function.