### PR TITLE
Allow for configuring extra rrdtool arguments to the default views

### DIFF
--- a/sample-config/pnp/config.php.in
+++ b/sample-config/pnp/config.php.in
@@ -208,7 +208,14 @@ $conf['use_calendar'] = 1;
 #
 # Define default views with title and start timerange in seconds 
 #
-# remarks: required escape on " with backslash
+# supported keys:
+#   'title' => The name of the view, e.g. "4 Hours"
+#   'start' => The number of seconds before the current time from whence the graph x-axis should start
+#   'extra_args' => additional arguments passed to rrdtool for this view's graph
+#
+# remarks: 
+#    required escape on " with backslash
+#    extra_args are appended to args/opts defined elsewhere (e.g. in templates), but no effort is made to de-duplicate
 #
 #$views[] = array('title' => 'One Hour',  'start' => (60*60) );
 $views[] = array('title' => '4 Hours',   'start' => (60*60*4) );

--- a/share/pnp/application/models/data.php
+++ b/share/pnp/application/models/data.php
@@ -1024,8 +1024,7 @@ class Data_Model extends System_Model
     public function buildXport($host,$service){
         // FIXME add max rows to config
         $this->XPORT = " -m 2000";
-        $this->XPORT .= " --start=".$this->TIMERANGE['start'];
-        $this->XPORT .= " --end=".$this->TIMERANGE['end'];
+        $this->XPORT .= $this->buildViewCmd(FALSE, $this->TIMERANGE['start'], $this->TIMERANGE['end']);
         $this->readXML($host,$service);
         $count = 0;
         $RRAs = array('MIN','MAX','AVERAGE');

--- a/share/pnp/application/views/graph_content.php
+++ b/share/pnp/application/views/graph_content.php
@@ -84,15 +84,24 @@ foreach($this->data->STRUCT as $key=>$value){
 		.Kohana::lang('common.datasource',$value['ds_name']) . " " 
 		."\">\n";
 	echo "<div start=".$value['TIMERANGE']['start']." end=".$value['TIMERANGE']['end']." style=\"width:".$value['GRAPH_WIDTH']."px; height:".$value['GRAPH_HEIGHT']."px; position:absolute; top:33px\" class=\"graph\" id=\"".$this->url."\" ></div>";
-        $path = pnp::addToUri( array(
-                                'host'   => $value['MACRO']['HOSTNAME'],
-                                'srv'    => $value['MACRO']['SERVICEDESC'],
-                                'view'   => $value['VIEW'],
-                                'source' => $value['SOURCE'],
-                                'start'  => $value['TIMERANGE']['start'],
-                                'end'    => $value['TIMERANGE']['end']
-                               ), FALSE
-                             );
+        
+	// build the URI which renders the dynamic graph image
+	$path = array('host'   => $value['MACRO']['HOSTNAME'],
+                      'srv'    => $value['MACRO']['SERVICEDESC'],
+                      'source' => $value['SOURCE']);
+
+	// only include `view` in the querystring if we are in a preset view; likewise, only 
+	// include timerange start/end if we are not in a preset view; this will help later
+	// to differentiate between preset and custom timeranges, for display purposes
+	if ($value['TIMERANGE']['type']=='views') {
+		$path['view']       =  $value['VIEW'];
+        } else {
+		$path['start']      =  $value['TIMERANGE']['start'];
+		$path['end']        =  $value['TIMERANGE']['end'];
+        }
+
+        $path = pnp::addToUri($path, FALSE);
+
         echo "<img class=\"graph\" src=\"".url::base(TRUE)."image" . $path . "\"></a>\n";
         echo "</div>\n";
    	echo "</div><p>\n";

--- a/share/pnp/application/views/timerange_box.php
+++ b/share/pnp/application/views/timerange_box.php
@@ -6,7 +6,7 @@ echo "</div>\n";
 echo "<div class=\"p4 ui-widget-content ui-corner-bottom\">\n";
 $start = $this->session->get('start','');
 $end   = $this->session->get('end','');
-$path  = pnp::addToUri(array('start' => $start,'end' => $end));
+$path  = pnp::addToUri(array('view' => '', 'start' => $start,'end' => $end));
 if($start && $end){
 	echo "<a class=\"multi0\" href=\"".$path."\">".Kohana::lang('common.timerange-selector-link')."</a><br>\n"; 
 }


### PR DESCRIPTION
Have extended the config to support adding an `extra_args` key to each element in the `$views[]` array, and updated `models/data.php` and `views/graph_content.php` to pass those args onto `rrdtool`, in as many places as I could find.  

Also slightly altered generation of `views/timerange_box.php` to make it easier to differentiate preset views from custom timeframe/overall views.