### PR TITLE
Fix tv_interval usage in process_perfdata

### DIFF
--- a/scripts/process_perfdata.pl.in
+++ b/scripts/process_perfdata.pl.in
@@ -177,7 +177,6 @@ if( ! defined($opt_gm) ){
 sub main {
     my $job = shift;
     my $t0 = [gettimeofday];
-    my $t1;
     my $rt;
     my $lines = 0;
     # Gearman Worker
@@ -185,8 +184,7 @@ sub main {
         print_log( "Gearman Worker Job start", 1 );
         %NAGIOS = parse_env($job->arg);
         $lines = process_perfdata();
-        $t1 = [gettimeofday];
-        $rt = tv_interval $t0, $t1;
+        $rt = tv_interval($t0, [gettimeofday]);
         $stats{runtime} += $rt;
         $stats{rows}++;
         if( ( int $stats{timet} / 60 ) < ( int time / 60 )){
@@ -218,7 +216,7 @@ sub main {
         %NAGIOS = parse_env();
         $lines = process_perfdata();
     }
-    $rt = tv_interval $t0, $t1;
+	$rt = tv_interval($t0, [gettimeofday]);
     $stats{runtime} = $rt;
     $stats{rows} = $lines;
     store_internals();


### PR DESCRIPTION
Fix usage of Time::HiRes::tv_interval() where the second argument to
tv_interval should be omitted OR an array reference.

This fixes errors like these on Perl 5.26.3 and Time::HiRes 1.9758:

  tv_interval() 2nd argument should be an array reference at \
      /opt/monitor/op5/pnp/process_perfdata.pl line 221.
  ERROR: Executed command exits with return code '255'
  ERROR: Command line was '/opt/monitor/op5/pnp/process_perfdata.pl \
    -n --bulk /opt/monitor/var/spool/perfdata/service_perfdata.1626159482'

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>