### PR TITLE
Fix undefined index error in graph_content.php

### DIFF
--- a/share/pnp/application/views/graph_content.php
+++ b/share/pnp/application/views/graph_content.php
@@ -88,7 +88,8 @@ foreach($this->data->STRUCT as $key=>$value){
 	# treated like a url fragment when zooming
 	$gid = array();
 	parse_str(ltrim($this->url, '?'), $gid);
-	$gid = htmlentities("?host=".urlencode($gid["host"])."&srv=".urlencode($gid["srv"]));
+	$srv = isset($gid['srv']) ? $gid['srv'] : '';
+	$gid = htmlentities("?host=".urlencode($gid["host"])."&srv=".urlencode($srv));
 	
 	echo "<div start=".$value['TIMERANGE']['start']." end=".$value['TIMERANGE']['end']." style=\"width:".$value['GRAPH_WIDTH']."px; height:".$value['GRAPH_HEIGHT']."px; position:absolute; top:33px\" class=\"graph\" id=\"".$gid."\" ></div>";
 	


### PR DESCRIPTION
After updating to PHP 7 we started seeing an error message `Undefined
index: srv` instead of the expected graph. This commit resolves the
issue by checking the index in graph_content.php before using it, and
defaulting to an empty string if missing.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>