### PR TITLE
Creation of dynamic property Special_Controller::$templates is deprecated

### DIFF
--- a/share/pnp/application/controllers/special.php
+++ b/share/pnp/application/controllers/special.php
@@ -6,7 +6,16 @@
  * @author     Joerg Linge
  * @license    GPL
  */
-class Special_Controller extends System_Controller  {
+ 
+class Special_Controller extends System_Controller {
+
+    // Explicitly declare the dynamic properties
+    public $templates;
+    public $url;
+    public $template;
+    public $tpl;
+    public $data;
+    public $view;
 
     public function __construct()
     {
@@ -15,15 +24,16 @@ class Special_Controller extends System_Controller  {
         $this->template->graph = $this->add_view('graph');
         $this->templates       = $this->data->getSpecialTemplates();
         $this->data->GRAPH_TYPE = 'special';
-        if($this->tpl == ''){
-            if($this->templates)
+        if ($this->tpl == '') {
+            if ($this->templates)
                 $this->tpl = $this->templates[0];
-                url::redirect('special?tpl='.$this->tpl, 302);
+                url::redirect('special?tpl=' . $this->tpl, 302);
         }
     }
 
-    public function index(){
-	$this->url = "?tpl=".$this->tpl;
+    public function index()
+    {
+        $this->url = "?tpl=" . $this->tpl;
         $this->template->zoom_header   = $this->add_view('zoom_header');
         $this->template->zoom_header->graph_width  = ($this->config->conf['zgraph_width'] + 140);
         $this->template->zoom_header->graph_height = ($this->config->conf['zgraph_height'] + 230);
@@ -38,7 +48,7 @@ class Special_Controller extends System_Controller  {
         $this->template->graph->widget_menu   = $this->add_view('widget_menu');
         $this->template->graph->graph_content->widget_graph  = $this->add_view('widget_graph');
         #print Kohana::debug($services);
-        $this->data->buildDataStruct('__special',$this->tpl,$this->view);
+        $this->data->buildDataStruct('__special', $this->tpl, $this->view);
         $this->template->graph->icon_box      = $this->add_view('icon_box');
         $this->template->graph->icon_box->position = "special";
         $this->template->graph->logo_box      = $this->add_view('logo_box');
@@ -48,5 +58,4 @@ class Special_Controller extends System_Controller  {
         $this->template->graph->header->title        = $this->data->MACRO['TITLE'];
         //print Kohana::debug($this->data);
     }
-
 }

--- a/share/pnp/application/helpers/pnp.php
+++ b/share/pnp/application/helpers/pnp.php
@@ -100,7 +100,7 @@ class pnp_Core {
 	    if($value === ''){
 		continue;
 	    }
-	    $uri .= $key."=".urlencode($value)."&";
+	    $uri .= $key."=".urlencode($value ?? '')."&";
         }
         return rtrim($uri,"&");
     }


### PR DESCRIPTION
Since upgrading our monitoring boxes to Debian 12 (Bookworm), this broke our pnp4nagios graphs.

This happened because due to the new PHP version installed and the dynamic properties being deprecated.

Example of error:
"Creation of dynamic property Special_Controller::$templates is deprecated"

This was raised as an issue initially:
https://github.com/ConSol-Monitoring/omd/issues/210